### PR TITLE
Fix button style and SwiftUI API for iOS 16

### DIFF
--- a/mawaddah-ios/PersonsTabView.swift
+++ b/mawaddah-ios/PersonsTabView.swift
@@ -57,9 +57,9 @@ struct PersonsTabView: View {
           }) {
             Image(systemName: "plus.circle.fill")
               .font(.system(size: 30))
-              .buttonStyle(.borderedProminent)
               .foregroundColor(borderColour)
           }
+          .buttonStyle(.borderedProminent)
         }
         .padding(EdgeInsets(top: 10, leading: 25, bottom: 10, trailing: 10))
         .background(

--- a/mawaddah-ios/Views/Questions/QuestionsTabView.swift
+++ b/mawaddah-ios/Views/Questions/QuestionsTabView.swift
@@ -19,7 +19,7 @@ struct QuestionsTabView: View {
             personStore.setRating(questionID: qid, rating: rating)
           }
         }
-        .onChange(of: personStore.selectedPersonID) { oldValue, newValue in
+        .onChange(of: personStore.selectedPersonID) { _ in
           // Reload ratings when switching persons
           viewModel.ratings = personStore.getRatingsForSelected()
           viewModel.index = 0


### PR DESCRIPTION
## Summary
- fix incorrect use of `.onChange` in QuestionsTabView for iOS 16 compatibility
- apply button style to the entire button in PersonsTabView

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683fc89a6094832992c2a52fccfe34cf